### PR TITLE
Webhook

### DIFF
--- a/lib/peoplegraph/client.rb
+++ b/lib/peoplegraph/client.rb
@@ -30,11 +30,28 @@ module PeopleGraph
       OpenStruct.new(profile)
     end
 
+    def search_by_company(company, options = {})
+      search(nil, nil, nil, company, options)
+    end
+
+    def search_by_email(email, options = {})
+      search(email, nil, nil, nil, options)
+    end
+
+    def search_by_name(name, options = {})
+      search(nil, nil, name, nil, options)
+    end
+
+    def search_by_url(url, options = {})
+      search(nil, url, nil, nil, options)
+    end
+
     protected
 
     def lookup(email = nil, url = nil, name = nil, company = nil, options = {})
       webhook_id = options.fetch(:webhook_id, nil)
       webhook_url = options.fetch(:webhook_url, nil)
+
       response = connection.get do |request|
         request.url '/v2/lookup'
         request.params['apiKey'] = api_key

--- a/lib/peoplegraph/client.rb
+++ b/lib/peoplegraph/client.rb
@@ -19,7 +19,6 @@ module PeopleGraph
 
     def initialize(api_key = ENV['PEOPLEGRAPH_API_KEY'], options = nil)
       @api_key = api_key
-      # /lookup?email=razvan@3desk.com&apiKey=hYxSdRmEif0GN7jwlmeQtVQbE3T1kBb1
       url = ENV['PEOPLEGRAPH_API_URL'] || 'https://api.peoplegraph.io'
       block = block_given? ? Proc.new : nil
       @connection = Faraday.new(url, options, &block)

--- a/lib/peoplegraph/client.rb
+++ b/lib/peoplegraph/client.rb
@@ -6,6 +6,14 @@ require 'ostruct'
 require 'peoplegraph'
 
 module PeopleGraph
+  # Client wraps a call to the `/lookup` endpoint.
+  # Supported params:
+  # - email
+  # - url
+  # - name
+  # - company
+  # - webhook_url
+  # - webhook_id
   class Client
     attr_reader :api_key, :connection
 

--- a/lib/peoplegraph/client.rb
+++ b/lib/peoplegraph/client.rb
@@ -24,7 +24,7 @@ module PeopleGraph
       @connection = Faraday.new(url, options, &block)
     end
 
-    def search(email = nil, url = nil, name = nil, company = nil, options = nil)
+    def search(email = nil, url = nil, name = nil, company = nil, options = {})
       profile = lookup(email, url, name, company, options)
       return nil if profile.nil?
       OpenStruct.new(profile)
@@ -32,7 +32,7 @@ module PeopleGraph
 
     protected
 
-    def lookup(email = nil, url = nil, name = nil, company = nil, options = nil)
+    def lookup(email = nil, url = nil, name = nil, company = nil, options = {})
       webhook_id = options.fetch(:webhook_id, nil)
       webhook_url = options.fetch(:webhook_url, nil)
       response = connection.get do |request|

--- a/lib/peoplegraph/client.rb
+++ b/lib/peoplegraph/client.rb
@@ -31,7 +31,10 @@ module PeopleGraph
     end
 
     protected
+
     def lookup(email = nil, url = nil, name = nil, company = nil, options = nil)
+      webhook_id = options.fetch(:webhook_id, nil)
+      webhook_url = options.fetch(:webhook_url, nil)
       response = connection.get do |request|
         request.url '/v2/lookup'
         request.params['apiKey'] = api_key
@@ -39,6 +42,8 @@ module PeopleGraph
         request.params['url'] = url unless url.nil?
         request.params['name'] = name unless name.nil?
         request.params['company'] = company unless company.nil?
+        request.params['webhookId'] = webhook_id unless webhook_id.nil?
+        request.params['webhookUrl'] = webhook_url unless webhook_url.nil?
         request.headers['accept'] = 'application/json'
       end
 

--- a/peoplegraph.gemspec
+++ b/peoplegraph.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'pry', '~> 0.10.1'
   spec.add_development_dependency 'rspec', '~> 3.3.0'
+  spec.add_development_dependency 'minitest', '~> 5.8', '>= 5.8.3'
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'minitest/autorun'
+require 'pry'
 require 'peoplegraph'
 
 class PeopleGraphClientTest < MiniTest::Unit::TestCase
@@ -37,16 +38,16 @@ class PeopleGraphClientTest < MiniTest::Unit::TestCase
 
   def test_result_found
     profile = @client.search('s.fontanelli@gmail.com')
+
     assert profile
     assert profile.name
     assert profile.email
     assert profile.bio
-    assert profile.profiles.to_a.count > 0
-    assert profile.companies.to_a.count > 0
-    assert profile.avatars.to_a.count > 0
-    assert profile.websites.to_a.count > 0
-    assert profile.locations.to_a.count > 0
-    assert profile.positions.to_a.count > 0
+    assert profile.profiles.to_a.size > 0
+    assert profile.companies.to_a.size > 0
+    assert profile.avatars.to_a.size > 0
+    assert profile.websites.to_a.size > 0
+    assert profile.locations.to_a.size > 0
   end
 
   def test_server_error


### PR DESCRIPTION
Add support for API webhooks.

From the [official documentation](http://dev.peoplegraph.io/docs#webhooks):

**Webhooks**

Webhooks allow you to receive the results of queries as soon as they are available. To do that you have to include the webhookUrl parameter in your request and the results will be posted to the webhook URL in the same format they are returned through a normal lookup API call.

In addition to the webhookUrl parameter you can also include the webhookId parameter in your request. In this case it will also be included in the JSON response which will be posted to the webhook URL.

For demo purposes, the example on the right uses http://echo.peoplegraph.io service which stores the result posted by the API when the call is ready.

If the call to the provided webhook URL fails we will retry 10 times with an exponential backoff.

```
# Example lookup using webhooks 
$ GET api.peoplegraph.io/v2/lookup?email=razvan@3desk.com&webhookUrl=http://echo.peoplegraph.io/key/webhook

# Check the webhook result from the above example 
$ GET echo.peoplegraph.io/key/webhook

# Example lookup using webhooks with webook ids 
$ GET api.peoplegraph.io/v2/lookup?email=razvan@3desk.com&webhookUrl=http://echo.peoplegraph.io/key/webhook2&webhookId=someId

# Check the webhook result from the above example 
$ GET echo.peoplegraph.io/key/webhook2
```
